### PR TITLE
Feat : 자유게시판 피드템플릿에 tabmenu 컴포넌트 추가

### DIFF
--- a/src/components/template/FeedTemplate/FeedTemplate.jsx
+++ b/src/components/template/FeedTemplate/FeedTemplate.jsx
@@ -2,6 +2,7 @@ import { FeedWrapper } from './styled';
 import FeedCard from '../../organisms/FeedCard/FeedCard';
 import TopNavBar from '../../molecules/TopNavBar/TopNavBar';
 import searchImg from '../../../assets/images/icon-search.png';
+import TabMenu from '../../organisms/TabMenu/TabMenu';
 
 const PostTemplate = () => {
   return (
@@ -12,6 +13,7 @@ const PostTemplate = () => {
         <FeedCard />
         <FeedCard />
       </ul>
+      <TabMenu />
     </FeedWrapper>
   );
 };

--- a/src/components/template/FeedTemplate/styled.jsx
+++ b/src/components/template/FeedTemplate/styled.jsx
@@ -3,10 +3,12 @@ import styled, { css } from 'styled-components';
 export const FeedWrapper = styled.section`
   ${({ theme }) => {
     return css`
-      width: 600px;
+      max-width: 600px;
       height: 100vh;
       background-color: ${theme.colors.colorBg};
       margin: 0 auto;
+      position: relative;
+      overflow: hidden;
     `;
   }}
 `;


### PR DESCRIPTION
## 제목
- 자유게시판 tabmenu 컴포넌트 추가

## ⚙️ 작업사항
- 자유게시판 템플릿에 tabmenu 컴포넌트를 추가했습니다.
- 

## 🗣 전달사항
- 이미 이전 작업 내용 머지된 상황이라 ,,,,,,,,,, 풀리퀘 이름 머라해야할지 몰라서 일단 이러케 적었답니다................ㅎㅎㅎㅎ... 추가로 커밋할 상황 생기면 수정하겠습니다!

## 📸 결과 스크린샷
<img width="600" alt="image" src="https://user-images.githubusercontent.com/77143425/208354415-670cd4fe-dbee-4dd9-929d-2af2b9e4176d.png">


## 📄 Issue Number
