### PR TITLE
Feature/splash 스플래쉬 반응형 구현

### DIFF
--- a/src/components/molecules/SplashLogoCard/SplashLogoCard.jsx
+++ b/src/components/molecules/SplashLogoCard/SplashLogoCard.jsx
@@ -1,0 +1,17 @@
+import SplashLogoCardWrapper from './styled';
+import Img from '../../atoms/Img/Img';
+import colorFullLogo from '../../../assets/images/color-full-logo.png';
+import titleLogo from '../../../assets/images/title-logo.png';
+import Star from '../../atoms/Star/Star';
+
+const SplashLogoCard = () => {
+  return (
+    <SplashLogoCardWrapper>
+      <Img src={colorFullLogo} width='90%' alt='부엉이 캐릭터' />
+      <Img src={titleLogo} width='70%' alt='던윗미 로고' />
+      <Star className='moon' />
+    </SplashLogoCardWrapper>
+  );
+};
+
+export default SplashLogoCard;

--- a/src/components/molecules/SplashLogoCard/styled.jsx
+++ b/src/components/molecules/SplashLogoCard/styled.jsx
@@ -1,0 +1,27 @@
+import styled from 'styled-components';
+
+const SplashLogoCardWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: absolute;
+  top: 10vh;
+  margin: 0 30%;
+
+  img:nth-child(2) {
+    padding-top: 18%;
+  }
+
+  .moon {
+    height: 9%;
+    width: 8%;
+    background: rgb(223, 208, 172);
+    border-radius: 41% 59% 100% 0 / 0 34% 66% 100%;
+    position: absolute;
+    top: 77%;
+    left: 23%;
+    animation: none;
+  }
+`;
+
+export default SplashLogoCardWrapper;

--- a/src/components/organisms/LoginButtonForm/styled.jsx
+++ b/src/components/organisms/LoginButtonForm/styled.jsx
@@ -5,15 +5,14 @@ const LoginButtonFormWrapper = styled.div`
     return css`
       width: 100%;
       height: 319px;
+      padding: 50px 34px 82px;
+      background-color: ${theme.colors.colorBg};
+      border-radius: 20px 20px 0 0;
       position: absolute;
       bottom: 0;
       left: 50%;
       transform: translateX(-50%);
-      // margin: 0 auto;
-      padding: 50px 34px 82px;
       text-align: center;
-      border-radius: 20px 20px 0 0;
-      background-color: ${theme.colors.colorBg};
 
       span {
         font-weight: 400;

--- a/src/components/organisms/SplashView/SplashView.jsx
+++ b/src/components/organisms/SplashView/SplashView.jsx
@@ -1,29 +1,10 @@
-import {
-  SplashViewWrapper,
-  SplashViewAnimation,
-  SymbolAnimationWrapper,
-} from './styled';
-import Img from '../../atoms/Img/Img';
-import titleLogo from '../../../assets/images/title-logo.png';
-import colorFullLogoLarge from '../../../assets/images/color-full-logo.png';
+import { SplashViewWrapper, SplashViewAnimation } from './styled';
+import SplashLogoCard from '../../molecules/SplashLogoCard/SplashLogoCard';
 
 const SplashView = () => {
   return (
     <SplashViewWrapper>
-      <SymbolAnimationWrapper>
-        <Img
-          className='owl'
-          src={colorFullLogoLarge}
-          width='200px'
-          alt='부엉이미지'
-        />
-        <Img
-          className='logoAnimation'
-          src={titleLogo}
-          width='140px'
-          alt='타이틀 로고'
-        />
-      </SymbolAnimationWrapper>
+      <SplashLogoCard />
       <SplashViewAnimation />
     </SplashViewWrapper>
   );

--- a/src/components/organisms/SplashView/styled.jsx
+++ b/src/components/organisms/SplashView/styled.jsx
@@ -28,32 +28,24 @@ export const SplashViewWrapper = styled.div`
   display: flex;
   justify-content: center;
   position: relative;
+  img:last-child {
+    animation: ${ball} 0.4s ease-out 0s infinite alternate;
+  }
+
+  span {
+    display: none;
+  }
 `;
 
 export const SplashViewAnimation = styled.div`
   width: 50px;
   height: 105px;
   background-color: rgb(218, 101, 58);
+  border-radius: 0% 100% 100% 0% / 46% 47% 53% 54%;
   box-shadow: 0 0 10px 15px rgb(218, 101, 58);
   position: absolute;
-  top: 510px;
-  left: 293px;
-  border-radius: 0% 100% 100% 0% / 46% 47% 53% 54%;
+  bottom: 25%;
+  left: 50%;
+  transform: translateX(-50%);
   animation: ${sunset} 2s forwards;
-`;
-
-export const SymbolAnimationWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-
-  .owl {
-    margin-top: 110px;
-  }
-
-  .logoAnimation {
-    height: 70px;
-    margin: 60px 0 61px 0;
-    animation: ${ball} 0.4s ease-out 0s infinite alternate;
-  }
 `;

--- a/src/components/template/SplashTemplate/LoginButtonTemplate.jsx
+++ b/src/components/template/SplashTemplate/LoginButtonTemplate.jsx
@@ -1,34 +1,15 @@
-import LoginButtonForm from '../../organisms/LoginButtonForm/LoginButtonForm';
+import { LoginButtonWrapper } from './styled';
 import StarCard from '../../molecules/StarCard/StarCard';
-import Star from '../../atoms/Star/Star';
-import { LoginButtonWrapper, SymbolWrapper } from './styled';
-import Img from '../../atoms/Img/Img';
-import titleLogo from '../../../assets/images/title-logo.png';
-import colorFullLogoLarge from '../../../assets/images/color-full-logo.png';
+import SplashLogoCard from '../../molecules/SplashLogoCard/SplashLogoCard';
+import LoginButtonForm from '../../organisms/LoginButtonForm/LoginButtonForm';
 
 const LoginButtonTemplate = () => {
   return (
-    <>
-      <LoginButtonWrapper>
-        <StarCard />
-        <Star className='moon' />
-        <SymbolWrapper>
-          <Img
-            className='owl'
-            src={colorFullLogoLarge}
-            width='200px'
-            alt='부엉이 이미지'
-          />
-          <Img
-            className='logo'
-            src={titleLogo}
-            width='140px'
-            alt='타이틀 로고'
-          />
-        </SymbolWrapper>
-      </LoginButtonWrapper>
+    <LoginButtonWrapper>
+      <StarCard />
+      <SplashLogoCard />
       <LoginButtonForm />
-    </>
+    </LoginButtonWrapper>
   );
 };
 

--- a/src/components/template/SplashTemplate/styled.jsx
+++ b/src/components/template/SplashTemplate/styled.jsx
@@ -31,33 +31,9 @@ export const LoginButtonWrapper = styled.section`
   max-width: 600px;
   height: 100%;
   background: no-repeat url(${LoginButtonBackground});
-  background-size: 100%;
-  margin: 0 auto;
-  // position: relative;
+  background-size: 100% 100vh;
+  position: relative;
   overflow: auto;
+  margin: 0 auto;
   animation: ${loginButtonOn} 2s;
-
-  .moon {
-    width: 16px;
-    height: 22px;
-    border-radius: 41% 59% 100% 0% / 0% 34% 66% 100%;
-    top: 375px;
-    left: 247px;
-    animation: none;
-  }
-`;
-
-export const SymbolWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-
-  .owl {
-    margin-top: 110px;
-  }
-
-  .logo {
-    height: 70px;
-    margin: 60px 0 61px 0;
-  }
 `;


### PR DESCRIPTION
## 제목
- 스플래쉬 반응형 구현

## ⚙️작업사항
- 스플래쉬 스크린 (가로 기준)반응형으로 구현하였습니다.
- 반복적인 코드를 하나의 컴포넌트로 생성 및 코드 수정하였습니다.

## 🗣전달사항
- 세로로 화면이 줄어들 때 동시에 이미지가 비율에 맞춰 줄어들지 않아, 작은 화면에서는 로고나 부엉이 이미지가 보이지 않는 경우가 있습니다.
(크롬 브라우저에서 기본적으로 제공하는 휴대폰 기기 14종 중 1종(Nest Hub, 1024 * 600)이 로고가 안보입니다.)
<img width="450" alt="스크린샷 2023-01-11 오후 1 38 36" src="https://user-images.githubusercontent.com/99248204/211719213-73d4b3ac-84ce-405d-b7e0-c7a1fb245f70.png">

- 미디어 쿼리를 사용하지 않고, %(퍼센트)로 반응형을 구현하였습니다.

## 📸결과 스크린샷

## 📄Issue Number
#95 