### PR TITLE
Feature/자유게시판 모바일에서의 너비 오류 수정, 상세 피드에서 댓글 클릭 시 프로필 이동 기능 구현

### DIFF
--- a/src/components/molecules/UserProfile/UserCommentProfileMore.jsx
+++ b/src/components/molecules/UserProfile/UserCommentProfileMore.jsx
@@ -43,7 +43,13 @@ const UserCommentProfileMore = ({
   return (
     <>
       <ProfileMoreWrapper>
-        <Link to='/profile'>
+        <Link
+          to={
+            currentAccountName === accountName
+              ? '/myprofile'
+              : `/userprofile/${accountName}`
+          }
+        >
           <UserCommentProfile src={src} userName={userName} time={time} />
         </Link>
         <button

--- a/src/components/molecules/UserProfile/styled.jsx
+++ b/src/components/molecules/UserProfile/styled.jsx
@@ -4,7 +4,7 @@ export const ProfileMoreWrapper = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  width: 565px;
+  max-width: 600px;
 `;
 
 export const UserProfileWrapper = styled.div`


### PR DESCRIPTION
## 제목
- 자유게시판 모바일에서의 너비 오류 수정

## ⚙️ 작업사항

- [x] UserProfileMore의 너비 고정값을 max-width로 변경했습니다. 프로필 오류도 잡혔습니다!
- [x] 상세 피드 내에서 댓글 작성한 프로필 이미지 클릭 시 사용자의 프로필로 이동하도록 하는 기능을 구현했습니다.


## 🗣 전달사항


## 📸 결과 스크린샷
- 피드
<div>
<img width="370" alt="image" src="https://user-images.githubusercontent.com/77143425/211730902-2296c10a-d5f2-485f-aaac-7cfedd3fded6.png">
<img width="349" alt="image" src="https://user-images.githubusercontent.com/77143425/211731016-e66e33fa-d66a-47ae-8d2f-a37f33938b08.png">
</div>

- 프로필
<div>
<img width="339" alt="image" src="https://user-images.githubusercontent.com/77143425/211731281-60f9125c-7649-4bf5-a688-4913f7f13f73.png">
<img width="342" alt="image" src="https://user-images.githubusercontent.com/77143425/211731218-92a2c4c6-fc0a-406e-9e59-a580898e1531.png">
</div>

- 댓글에서 이미지 클릭 시 프로필로 이동
<div>
<img width="370" alt="gif" src="https://user-images.githubusercontent.com/77143425/211742535-7fa48ae9-fc4d-429f-ae61-43847883921d.gif">
<img width="370" alt="gif" src="https://user-images.githubusercontent.com/77143425/211742550-82859307-07a6-48cd-b287-9a682de31ddd.gif">
</div>



## 📄 Issue Number
#99 #102 